### PR TITLE
Add font-noto-mono (latest) (#927)

### DIFF
--- a/Casks/font-noto-mono.rb
+++ b/Casks/font-noto-mono.rb
@@ -1,0 +1,11 @@
+cask 'font-noto-mono' do
+  version :latest
+  sha256 :no_check
+
+  # noto-website-2.storage.googleapis.com was verified as official when first introduced to the cask
+  url 'https://noto-website-2.storage.googleapis.com/pkgs/NotoMono-hinted.zip'
+  name 'Noto Mono'
+  homepage 'https://www.google.com/get/noto/#mono-mono'
+
+  font 'NotoMono-Regular.ttf'
+end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed

